### PR TITLE
feat: date formatting and first name/last name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8686,6 +8686,11 @@
         }
       }
     },
+    "date-fns": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.15.0.tgz",
+      "integrity": "sha512-ZCPzAMJZn3rNUvvQIMlXhDr4A+Ar07eLeGsGREoWU19a3Pqf5oYa+ccd+B3F6XVtQY6HANMFdOQ8A+ipFnvJdQ=="
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@emotion/styled": "^10.0.23",
     "@govtechsg/decentralized-renderer-react-components": "^2.3.0",
     "@hot-loader/react-dom": "^16.11.0",
+    "date-fns": "^2.15.0",
     "debug": "4.1.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/src/templates/certificateOfAchievement/__tests__/certificateOfAchievement.test.tsx
+++ b/src/templates/certificateOfAchievement/__tests__/certificateOfAchievement.test.tsx
@@ -4,6 +4,13 @@ import { render } from "@testing-library/react";
 import React from "react";
 
 describe("customTemplate", () => {
+  it("should render the certificate provided by the document", () => {
+    const { queryByText } = render(
+      <CertificateOfAchievement document={sampleCertificate} handleObfuscation={() => void 0} />
+    );
+    // eslint-disable-next-line jest/no-truthy-falsy
+    expect(queryByText("Certificate of Achievement")).toBeTruthy();
+  });
   it("should render with recipient name provided by the document", () => {
     const { queryByText } = render(
       <CertificateOfAchievement document={sampleCertificate} handleObfuscation={() => void 0} />
@@ -17,5 +24,20 @@ describe("customTemplate", () => {
     );
     // eslint-disable-next-line jest/no-truthy-falsy
     expect(queryByText("GovTech Internship Programme")).toBeTruthy();
+  });
+  it("should render with the start date provided by the document", () => {
+    const { queryByText } = render(
+      <CertificateOfAchievement document={{ ...sampleCertificate }} handleObfuscation={() => void 0} />
+    );
+    // eslint-disable-next-line jest/no-truthy-falsy
+    expect(queryByText("1 Aug 2019")).toBeTruthy();
+  });
+  it("should render with the signatory details provided by the document", () => {
+    const { queryByText } = render(
+      <CertificateOfAchievement document={{ ...sampleCertificate }} handleObfuscation={() => void 0} />
+    );
+    // eslint-disable-next-line jest/no-truthy-falsy
+    expect(queryByText("Evangeline Chua")).toBeTruthy();
+    expect(queryByText("Chief People Officer")).toBeTruthy();
   });
 });

--- a/src/templates/certificateOfAchievement/certificateOfAchievement.tsx
+++ b/src/templates/certificateOfAchievement/certificateOfAchievement.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from "react";
 import { TemplateProps } from "@govtechsg/decentralized-renderer-react-components";
 import { css } from "@emotion/core";
+import { format } from "date-fns";
 import { GovTechCertificateTemplate } from "../sample";
 import certificateBase from "../../core/certificate-base.png";
 
@@ -93,14 +94,15 @@ export const CertificateOfAchievement: FunctionComponent<TemplateProps<GovTechCe
       <div css={container} className={className} id="certificate-of-achievement">
         <div css={textRegion}>
           <DocumentTitle title={document.name} />
-          <div css={programmeName}>🏆 Achievement unlocked! Way to go!</div>
+          <div css={programmeName}>Achievement unlocked! Way to go!</div>
 
           <div css={recipientName}>{document.recipient.name}</div>
 
           <div css={programmeName}>You have completed the {document.programme.name}.</div>
 
           <div css={dateRange}>
-            {document.programme.startDate} to {document.programme.endDate}
+            {format(new Date(document.programme.startDate), "d MMM yyyy")} to{" "}
+            {format(new Date(document.programme.endDate), "d MMM yyyy")}
           </div>
 
           <img css={signature} src={document.signatory.signature} />

--- a/src/templates/certificateOfAchievement/certificateOfAchievement.tsx
+++ b/src/templates/certificateOfAchievement/certificateOfAchievement.tsx
@@ -96,7 +96,9 @@ export const CertificateOfAchievement: FunctionComponent<TemplateProps<GovTechCe
           <DocumentTitle title={document.name} />
           <div css={programmeName}>Achievement unlocked! Way to go!</div>
 
-          <div css={recipientName}>{document.recipient.name}</div>
+          <div css={recipientName}>
+            {document.recipient.firstName} {document.recipient.firstName}
+          </div>
 
           <div css={programmeName}>You have completed the {document.programme.name}.</div>
 

--- a/src/templates/sample.ts
+++ b/src/templates/sample.ts
@@ -27,7 +27,7 @@ export const sampleCertificate: GovTechCertificateTemplate = {
   },
   programme: {
     name: "GovTech Internship Programme",
-    startDate: "12 Aug 2019",
+    startDate: "1 Aug 2019",
     endDate: "29 Nov 2019"
   },
   signatory: {

--- a/src/templates/sample.ts
+++ b/src/templates/sample.ts
@@ -3,7 +3,8 @@ import { Document } from "@govtechsg/decentralized-renderer-react-components";
 export interface GovTechCertificateTemplate extends Document {
   name: string;
   recipient: {
-    name: string;
+    firstName: string;
+    lastName: string;
     email?: string;
     nric?: string;
   };
@@ -23,12 +24,13 @@ export interface GovTechCertificateTemplate extends Document {
 export const sampleCertificate: GovTechCertificateTemplate = {
   name: "Certificate of Achievement",
   recipient: {
-    name: "John Doe"
+    firstName: "Jia Jian",
+    lastName: "Goi"
   },
   programme: {
     name: "GovTech Internship Programme",
-    startDate: "1 Aug 2019",
-    endDate: "29 Nov 2019"
+    startDate: "4 May 2020",
+    endDate: "7 Oct 2020"
   },
   signatory: {
     name: "Evangeline Chua",


### PR DESCRIPTION
In this MR, we used

- `date-fns` to properly format dates
- split off `name` into `firstName` and `lastName` to follow Access fields